### PR TITLE
Require libgcc

### DIFF
--- a/conda-build/meta.yaml
+++ b/conda-build/meta.yaml
@@ -12,6 +12,7 @@ requirements:
 
   run:
     - python
+    - libgcc
 
 test:
   imports:

--- a/conda-build/meta.yaml
+++ b/conda-build/meta.yaml
@@ -9,6 +9,7 @@ requirements:
   build:
     - python
     - setuptools
+    - libgcc
 
   run:
     - python

--- a/conda-build/meta.yaml
+++ b/conda-build/meta.yaml
@@ -9,11 +9,11 @@ requirements:
   build:
     - python
     - setuptools
-    - libgcc
+    - libgcc # [not win]
 
   run:
     - python
-    - libgcc
+    - libgcc # [not win]
 
 test:
   imports:


### PR DESCRIPTION
Apparently putting libgcc in the runtime requirements can avoid some libgxx version problems.  I've added it to the build dependencies as well, in the hopes of bypassing any potential situation where the library it finds while building isn't the one we install while using.

Also added a selector so it's not attempted on windows for now.
